### PR TITLE
feat(frontend): TodoモデルとAPI型定義にdueDateフィールドを追加

### DIFF
--- a/frontend/src/components/todo/TodoForm.tsx
+++ b/frontend/src/components/todo/TodoForm.tsx
@@ -6,18 +6,20 @@ import { TODO_NAME_MAX_LENGTH, TODO_DETAIL_MAX_LENGTH } from '../../hooks/useTod
 import { FieldError } from '../FieldError'
 
 type TodoFormProps = Readonly<{
-  onSubmit: (name: string, detail: string) => Promise<readonly ValidationError[] | undefined>
+  onSubmit: (name: string, detail: string, dueDate: string | null) => Promise<readonly ValidationError[] | undefined>
 }>
 
 type FormState = Readonly<{
   name: string
   detail: string
+  dueDate: string
 }>
 
 export const TodoForm = ({ onSubmit }: TodoFormProps) => {
   const [formState, setFormState] = useState<FormState>({
     name: '',
     detail: '',
+    dueDate: '',
   })
   const [errors, setErrors] = useState<readonly ValidationError[]>([])
 
@@ -28,12 +30,13 @@ export const TodoForm = ({ onSubmit }: TodoFormProps) => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    const validationErrors = await onSubmit(formState.name, formState.detail)
+    const dueDate = formState.dueDate === '' ? null : formState.dueDate
+    const validationErrors = await onSubmit(formState.name, formState.detail, dueDate)
     if (validationErrors != null && validationErrors.length > 0) {
       setErrors(validationErrors)
       return
     }
-    setFormState({ name: '', detail: '' })
+    setFormState({ name: '', detail: '', dueDate: '' })
     setErrors([])
   }
 

--- a/frontend/src/components/todo/TodoList.tsx
+++ b/frontend/src/components/todo/TodoList.tsx
@@ -9,13 +9,19 @@ import { FieldError } from '../FieldError'
 type TodoListProps = Readonly<{
   todos: readonly Todo[]
   onDelete: (id: number) => void
-  onEdit: (id: number, name: string, detail: string) => Promise<readonly ValidationError[] | undefined>
+  onEdit: (
+    id: number,
+    name: string,
+    detail: string,
+    dueDate: string | null,
+  ) => Promise<readonly ValidationError[] | undefined>
 }>
 
 type EditState = Readonly<{
   id: number
   name: string
   detail: string
+  dueDate: string
   errors: readonly ValidationError[]
 }> | null
 
@@ -23,7 +29,7 @@ export const TodoList = ({ todos, onDelete, onEdit }: TodoListProps) => {
   const [editState, setEditState] = useState<EditState>(null)
 
   const handleEditClick = (todo: Todo) => {
-    setEditState({ id: todo.id, name: todo.name, detail: todo.detail, errors: [] })
+    setEditState({ id: todo.id, name: todo.name, detail: todo.detail, dueDate: todo.dueDate ?? '', errors: [] })
   }
 
   const handleCancelClick = () => {
@@ -38,7 +44,8 @@ export const TodoList = ({ todos, onDelete, onEdit }: TodoListProps) => {
 
   const handleSaveClick = async () => {
     if (editState == null) return
-    const validationErrors = await onEdit(editState.id, editState.name.trim(), editState.detail)
+    const dueDate = editState.dueDate === '' ? null : editState.dueDate
+    const validationErrors = await onEdit(editState.id, editState.name.trim(), editState.detail, dueDate)
     if (validationErrors) {
       setEditState({ ...editState, errors: validationErrors })
       return

--- a/frontend/src/hooks/useTodo.ts
+++ b/frontend/src/hooks/useTodo.ts
@@ -26,8 +26,13 @@ type TodoService = Readonly<{
   todos: readonly Todo[]
   isLoading: boolean
   fetchTodos: () => Promise<void>
-  addTodo: (name: string, detail: string) => Promise<readonly ValidationError[] | undefined>
-  updateTodo: (id: number, name: string, detail: string) => Promise<readonly ValidationError[] | undefined>
+  addTodo: (name: string, detail: string, dueDate: string | null) => Promise<readonly ValidationError[] | undefined>
+  updateTodo: (
+    id: number,
+    name: string,
+    detail: string,
+    dueDate: string | null,
+  ) => Promise<readonly ValidationError[] | undefined>
   removeTodo: (id: number) => Promise<void>
   validateTodo: (name: string, detail: string) => readonly ValidationError[]
 }>
@@ -42,7 +47,7 @@ export const useTodo = (): TodoService => {
   }, [apiClient])
 
   const addTodo = useCallback(
-    async (name: string, detail: string): Promise<readonly ValidationError[] | undefined> => {
+    async (name: string, detail: string, dueDate: string | null): Promise<readonly ValidationError[] | undefined> => {
       // クライアントバリデーション
       const clientErrors = validateTodoForm(name, detail)
       if (clientErrors.length > 0) {
@@ -50,7 +55,7 @@ export const useTodo = (): TodoService => {
       }
 
       // API 呼び出し（unique_violation 等はサーバーでのみ検出）
-      const result = await apiClient.post('/todo/', { name, detail })
+      const result = await apiClient.post('/todo/', { name, detail, dueDate })
       if (!result.ok) {
         return result.error.errors
       }
@@ -60,7 +65,12 @@ export const useTodo = (): TodoService => {
   )
 
   const updateTodo = useCallback(
-    async (id: number, name: string, detail: string): Promise<readonly ValidationError[] | undefined> => {
+    async (
+      id: number,
+      name: string,
+      detail: string,
+      dueDate: string | null,
+    ): Promise<readonly ValidationError[] | undefined> => {
       // クライアントバリデーション
       const clientErrors = validateTodoForm(name, detail)
       if (clientErrors.length > 0) {
@@ -68,7 +78,7 @@ export const useTodo = (): TodoService => {
       }
 
       // API 呼び出し（unique_violation 等はサーバーでのみ検出）
-      const result = await apiClient.put<Todo, ValidationErrorResponse>(`/todo/${id}/`, { name, detail })
+      const result = await apiClient.put<Todo, ValidationErrorResponse>(`/todo/${id}/`, { name, detail, dueDate })
       if (!result.ok) {
         return result.error.errors
       }

--- a/frontend/src/models/todo.ts
+++ b/frontend/src/models/todo.ts
@@ -5,4 +5,5 @@ export type Todo = Readonly<{
   id: number
   name: string
   detail: string
+  dueDate: string | null
 }>

--- a/frontend/src/services/apiEndpoints.ts
+++ b/frontend/src/services/apiEndpoints.ts
@@ -6,11 +6,13 @@ import type { User } from '../models/user'
 export type CreateTodoRequest = Readonly<{
   name: string
   detail: string
+  dueDate: string | null
 }>
 
 export type UpdateTodoRequest = Readonly<{
   name: string
   detail: string
+  dueDate: string | null
 }>
 
 export type LoginRequest = Readonly<{

--- a/frontend/tests/pages/__snapshots__/DashboardPage.test.tsx.snap
+++ b/frontend/tests/pages/__snapshots__/DashboardPage.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`DashboardPage > TODO更新 > 値変更→保存ボタンでPUT APIが�
   {
     "data": {
       "detail": "Updated Detail",
+      "dueDate": null,
       "name": "Updated Todo",
     },
     "method": "PUT",
@@ -27,6 +28,7 @@ exports[`DashboardPage > TODO追加 > タスク名入力→追加ボタンでPOS
   {
     "data": {
       "detail": "New Detail",
+      "dueDate": null,
       "name": "New Todo",
     },
     "method": "POST",


### PR DESCRIPTION
期限設定機能のPR(1/3)
APIリクエスト、レスポンスの型に期限を表すdueDateを追加
UIへの変更はなし

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional due date to the Todo domain and propagates it through the data flow without changing visible UI.
> 
> - Extend `Todo` model and API request types (`CreateTodoRequest`, `UpdateTodoRequest`) with `dueDate: string | null`
> - Update `useTodo` `addTodo`/`updateTodo` signatures and payloads to include `dueDate`; keep client-side validation unchanged
> - Thread `dueDate` through `TodoForm` and `TodoList` state and submit/edit handlers, normalizing empty strings to `null` and resetting state accordingly
> - Refresh snapshots to assert `dueDate: null` in POST/PUT requests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c68be247d742354b56724188ccd33bd77e873db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->