### PR TITLE
タスク完了バックエンド

### DIFF
--- a/backend/app/routers/todo.py
+++ b/backend/app/routers/todo.py
@@ -2,7 +2,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.models.user import User
-from app.schemas.todo import TodoCreate, TodoUpdate, TodoResponse
+from app.schemas.todo import TodoCreate, TodoResponse
 from app.dependencies.auth import get_current_user
 from app.dependencies.container import get_todo_service
 from app.services.todo import TodoService
@@ -55,11 +55,11 @@ def get_todo(
 @router.put("/{todo_id}/", response_model=TodoResponse)
 def update_todo(
     todo_id: int,
-    todo_data: TodoUpdate,
+    todo_data: TodoCreate,
     current_user: User = Depends(get_current_user),
     service: TodoService = Depends(get_todo_service),
 ):
-    """Todoを更新（部分更新対応）"""
+    """Todoを更新（全置換）"""
     try:
         todo = service.update_todo(
             todo_id,

--- a/backend/app/schemas/todo.py
+++ b/backend/app/schemas/todo.py
@@ -48,35 +48,6 @@ class TodoCreate(TodoBase):
     pass
 
 
-def validate_optional_not_empty(v: str | None) -> str | None:
-    """Optional文字列で、値が設定された場合は空でないことを確認"""
-    if v is not None and (not v or not v.strip()):
-        raise PydanticCustomError(
-            "required",
-            "Field is required",
-        )
-    return v
-
-
-# Optional版の必須文字列型（値が設定された場合のみ空でないことをチェック）
-OptionalRequiredStr = Annotated[
-    Optional[str], AfterValidator(validate_optional_not_empty)
-]
-
-
-class TodoUpdate(BaseModel):
-    """更新用スキーマ（部分更新対応）
-
-    すべてのフィールドがOptionalで、リクエストに含まれるフィールドのみ更新される。
-    ただしnameが指定された場合は空でないことをバリデーションする。
-    """
-
-    name: OptionalRequiredStr = Field(default=None, max_length=100)
-    detail: Optional[str] = Field(default=None, max_length=500)
-    due_date: ValidatedDate = Field(default=None, alias="dueDate")
-    is_completed: Optional[bool] = Field(default=None, alias="isCompleted")
-
-
 class TodoResponse(TodoBase):
     id: int
     owner: Optional[int] = Field(default=None, validation_alias="owner_id")

--- a/backend/app/services/todo.py
+++ b/backend/app/services/todo.py
@@ -2,7 +2,7 @@ from typing import List, NewType
 from sqlalchemy.orm import Session
 
 from app.models.todo import Todo
-from app.schemas.todo import TodoCreate, TodoUpdate
+from app.schemas.todo import TodoCreate
 from app.repositories.todo import TodoRepository
 from app.exceptions import NotFoundError, DuplicateError
 
@@ -10,7 +10,6 @@ from app.exceptions import NotFoundError, DuplicateError
 # ビジネスバリデーション完了済みのTODOデータを表す型
 # 静的型チェッカーがバリデーション済みかどうかを区別できる
 ValidatedTodoData = NewType("ValidatedTodoData", TodoCreate)
-ValidatedTodoUpdateData = NewType("ValidatedTodoUpdateData", dict)
 
 
 class TodoService:
@@ -59,53 +58,11 @@ class TodoService:
         )
 
     def _apply_update(self, todo: Todo, data: ValidatedTodoData) -> None:
-        """ValidatedTodoData を使ってTodoエンティティを更新する（全置換）"""
+        """ValidatedTodoData を使ってTodoエンティティを更新する"""
         todo.name = data.name
         todo.detail = data.detail or ""
         todo.due_date = data.due_date
         todo.is_completed = data.is_completed
-
-    def _validate_update(
-        self, owner_id: int, todo: Todo, data: TodoUpdate
-    ) -> ValidatedTodoUpdateData:
-        """更新データのバリデーションを行い、バリデーション済みデータを返す
-
-        Args:
-            owner_id: オーナーID
-            todo: 更新対象のTodoエンティティ
-            data: バリデーション対象の更新データ
-
-        Returns:
-            ValidatedTodoUpdateData: バリデーション済みの更新データ
-                （設定されたフィールドのみ）
-
-        Raises:
-            DuplicateError: 名前が重複している場合
-        """
-        # exclude_unset=Trueで実際にリクエストに含まれるフィールドのみ取得
-        # by_alias=Trueでエイリアス名（dueDate, isCompleted）をPython名に変換
-        update_data = data.model_dump(exclude_unset=True, by_alias=False)
-
-        # 名前が更新される場合は重複チェック
-        if "name" in update_data:
-            if self.repo.check_name_exists(
-                owner_id, update_data["name"], exclude_id=todo.id
-            ):
-                raise DuplicateError(
-                    f"Task with name '{update_data['name']}' already exists",
-                    field="name",
-                )
-
-        return ValidatedTodoUpdateData(update_data)
-
-    def _apply_partial_update(
-        self, todo: Todo, update_data: ValidatedTodoUpdateData
-    ) -> None:
-        """リクエストに含まれるフィールドのみTodoエンティティを更新する"""
-        for field, value in update_data.items():
-            if field == "detail":
-                value = value or ""
-            setattr(todo, field, value)
 
     def create_todo(self, data: TodoCreate, owner_id: int) -> Todo:
         validated = self._validate_todo(owner_id, data)
@@ -122,16 +79,12 @@ class TodoService:
             raise NotFoundError("Todo not found")
         return todo
 
-    def update_todo(self, todo_id: int, data: TodoUpdate, owner_id: int) -> Todo:
-        """Todoを更新する（部分更新対応）
-
-        リクエストに含まれるフィールドのみ更新される。
-        """
+    def update_todo(self, todo_id: int, data: TodoCreate, owner_id: int) -> Todo:
         todo = self.get_todo(todo_id, owner_id)
 
-        validated = self._validate_update(owner_id, todo, data)
+        validated = self._validate_todo(owner_id, data, exclude_id=todo_id)
 
-        self._apply_partial_update(todo, validated)
+        self._apply_update(todo, validated)
         self.db.commit()
         self.db.refresh(todo)
         return todo

--- a/backend/tests/test_todo.py
+++ b/backend/tests/test_todo.py
@@ -352,10 +352,8 @@ class TestUpdateTodo:
         assert data["errors"][0]["field"] == "name"
         assert data["errors"][0]["reason"] == "required"
 
-    def test_partial_update_without_name(
-        self, client, auth_headers, test_user, test_db
-    ):
-        """部分更新：nameを省略してdetailのみ更新できる"""
+    def test_update_todo_name_missing(self, client, auth_headers, test_user, test_db):
+        """タスク名フィールドが欠落している場合は422エラー"""
         # Todoを作成
         todo = Todo(name="Original Task", detail="Original", owner_id=test_user.id)
         test_db.add(todo)
@@ -365,45 +363,15 @@ class TestUpdateTodo:
         response = client.put(
             f"/api/todo/{todo.id}/",
             headers=auth_headers,
-            json={"detail": "Updated Detail"},  # nameフィールドなし
+            json={"detail": "Test Detail"},  # nameフィールドなし
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 422
         data = response.json()
-        assert data["name"] == "Original Task"  # 元の値を維持
-        assert data["detail"] == "Updated Detail"  # 更新される
-
-    def test_partial_update_preserves_unspecified_fields(
-        self, client, auth_headers, test_user, test_db
-    ):
-        """部分更新：指定しないフィールドは既存の値が維持される"""
-        from datetime import date
-
-        # Todoを作成（すべてのフィールドを設定）
-        todo = Todo(
-            name="Original Task",
-            detail="Original Detail",
-            due_date=date(2026, 12, 31),
-            is_completed=True,
-            owner_id=test_user.id,
-        )
-        test_db.add(todo)
-        test_db.commit()
-        test_db.refresh(todo)
-
-        # nameのみ更新
-        response = client.put(
-            f"/api/todo/{todo.id}/",
-            headers=auth_headers,
-            json={"name": "Updated Task"},
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["name"] == "Updated Task"
-        assert data["detail"] == "Original Detail"  # 維持
-        assert data["dueDate"] == "2026-12-31"  # 維持
-        assert data["isCompleted"] is True  # 維持
+        assert data["type"] == "validation_error"
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["field"] == "name"
+        assert data["errors"][0]["reason"] == "required"
 
 
 class TestDeleteTodo:


### PR DESCRIPTION
Implement backend support for marking todos as completed.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e100d6e-8f1b-45a8-bb99-d20bad42381a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e100d6e-8f1b-45a8-bb99-d20bad42381a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds backend support for tracking todo completion status.
> 
> - Add `is_completed` boolean (default `False`) to `models/todo.Todo`
> - Update `schemas/todo.py` to accept/return `isCompleted` for create/response and enable `populate_by_name`
> - Persist and update `is_completed` in `services/todo.TodoService` during create/update
> - Add `tests/test_todo_completion.py` covering create with defaults/explicit flags, update toggling, list/get inclusion of `isCompleted`, and 404 on modifying others’ tasks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1658eac2cf363700f0b77637ab8450702fe1cb9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->