### PR TITLE
fix(frontend): latestOnly GET中断の挙動を明確化

### DIFF
--- a/frontend/src/services/api-client.ts
+++ b/frontend/src/services/api-client.ts
@@ -13,7 +13,7 @@ import type {
 import config from '../config'
 import { type Result, err, ok } from '../models/result'
 import { authToken } from './authToken'
-import { createFetchClient, isFetchHttpError } from './http/fetch-client'
+import { createFetchClient, isFetchAbortError, isFetchHttpError } from './http/fetch-client'
 
 type ApiGetOptions = Readonly<{
   key?: string
@@ -73,7 +73,7 @@ export type ApiClientOptions = Readonly<{
 
 export const createApiClient = (options: ApiClientOptions = {}, callbacks: ApiClientCallbacks): ApiClient => {
   const { onRequestStart, onRequestEnd } = callbacks
-  const latestOnlyRequests = new Map<string, { abort: () => void }>()
+  const abortControllers = new Map<string, { abort: () => void }>()
 
   const fetchClient = createFetchClient({
     baseURL: config.API_BASE_URL,
@@ -153,31 +153,38 @@ export const createApiClient = (options: ApiClientOptions = {}, callbacks: ApiCl
         let abortCurrent: (() => void) | undefined
 
         if (shouldAbortPrevious && requestKey) {
-          latestOnlyRequests.get(requestKey)?.abort()
+          abortControllers.get(requestKey)?.abort()
 
           abortController = new AbortController()
           abortCurrent = () => {
             abortController?.abort()
           }
-          latestOnlyRequests.set(requestKey, { abort: abortCurrent })
+          abortControllers.set(requestKey, { abort: abortCurrent })
         }
 
         try {
-          return fetchClient.request<ApiResponse<'get', E>>({
+          return await fetchClient.request<ApiResponse<'get', E>>({
             method: 'GET',
             url,
             query: resolvedParams,
             signal: abortController?.signal,
             headers: toAuthorizationHeaders(),
           })
+        } catch (error) {
+          if (isFetchAbortError(error)) {
+            // latestOnly による中断は FetchAbortError として上位へ再送出して扱いを明確化する。
+            throw error
+          }
+
+          throw error
         } finally {
           if (
             shouldAbortPrevious &&
             requestKey &&
             abortCurrent &&
-            latestOnlyRequests.get(requestKey)?.abort === abortCurrent
+            abortControllers.get(requestKey)?.abort === abortCurrent
           ) {
-            latestOnlyRequests.delete(requestKey)
+            abortControllers.delete(requestKey)
           }
         }
       }),

--- a/frontend/src/services/http/fetch-client.ts
+++ b/frontend/src/services/http/fetch-client.ts
@@ -61,6 +61,8 @@ export class FetchAbortError extends Error {
   }
 }
 
+export const isFetchAbortError = (error: unknown): error is FetchAbortError => error instanceof FetchAbortError
+
 const isAbortError = (error: unknown): boolean => error instanceof Error && error.name === 'AbortError'
 
 const appendQuery = (searchParams: URLSearchParams, key: string, value: unknown): void => {

--- a/frontend/tests/services/api-client-behavior.test.ts
+++ b/frontend/tests/services/api-client-behavior.test.ts
@@ -135,12 +135,111 @@ describe('ApiClient behavior', () => {
   })
 
   it('latestOnlyでも後続リクエストは解決できる', async () => {
-    let firstRequest = true
+    const abortError = () => Object.assign(new Error('aborted'), { name: 'AbortError' })
+    const firstSignalState = { aborted: false }
+    let requestCount = 0
 
-    const fetchImpl: typeof fetch = vi.fn(async () => {
-      if (firstRequest) {
-        firstRequest = false
-        return new Promise<Response>(() => {})
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      requestCount += 1
+      const signal = init?.signal
+
+      if (requestCount === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => {
+            firstSignalState.aborted = signal.aborted
+            reject(abortError())
+          })
+        })
+      }
+
+      fetchCalls.push({ url: String(_input), init })
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    const apiClient = createApiClient(
+      { fetchImpl },
+      {
+        onRequestStart: () => {},
+        onRequestEnd: () => {},
+      },
+    )
+
+    const first = apiClient.get('/todo/', {
+      params: {},
+      options: { key: 'todo-search', mode: 'latestOnly' },
+    })
+    const firstResult = first.catch((error: unknown) => error)
+    const second = apiClient.get('/todo/', {
+      params: {},
+      options: { key: 'todo-search', mode: 'latestOnly' },
+    })
+
+    await expect(second).resolves.toEqual([])
+    await expect(firstResult).resolves.toMatchObject({ kind: 'abort' })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(firstSignalState.aborted).toBe(true)
+  })
+
+  it('latestOnlyは別keyのGETを中断しない', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      fetchCalls.push({ url: String(_input), init })
+      return new Promise<Response>((resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+        )
+        setTimeout(
+          () =>
+            resolve(
+              new Response(JSON.stringify([]), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            ),
+          0,
+        )
+      })
+    })
+
+    const apiClient = createApiClient(
+      { fetchImpl },
+      {
+        onRequestStart: () => {},
+        onRequestEnd: () => {},
+      },
+    )
+
+    const first = apiClient.get('/todo/', {
+      params: {},
+      options: { key: 'todo-search-1', mode: 'latestOnly' },
+    })
+    const second = apiClient.get('/todo/', {
+      params: {},
+      options: { key: 'todo-search-2', mode: 'latestOnly' },
+    })
+
+    await expect(first).resolves.toEqual([])
+    await expect(second).resolves.toEqual([])
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchCalls.every((call) => call.init?.signal?.aborted !== true)).toBe(true)
+  })
+
+  it('中断後に同一keyで再実行してもcontrollerがリークしない', async () => {
+    const abortError = () => Object.assign(new Error('aborted'), { name: 'AbortError' })
+    const signals: AbortSignal[] = []
+
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      const signal = init?.signal
+      if (signal) {
+        signals.push(signal)
+      }
+
+      if (signals.length === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(abortError()))
+        })
       }
 
       return new Response(JSON.stringify([]), {
@@ -161,14 +260,26 @@ describe('ApiClient behavior', () => {
       params: {},
       options: { key: 'todo-search', mode: 'latestOnly' },
     })
+    const firstResult = first.catch((error: unknown) => error)
     const second = apiClient.get('/todo/', {
       params: {},
       options: { key: 'todo-search', mode: 'latestOnly' },
     })
 
+    await expect(firstResult).resolves.toMatchObject({ kind: 'abort' })
     await expect(second).resolves.toEqual([])
-    expect(fetchImpl).toHaveBeenCalledTimes(2)
 
-    first.catch(() => {})
+    const secondSignal = signals[1]
+    expect(secondSignal?.aborted).toBe(false)
+
+    await expect(
+      apiClient.get('/todo/', {
+        params: {},
+        options: { key: 'todo-search', mode: 'latestOnly' },
+      }),
+    ).resolves.toEqual([])
+
+    expect(secondSignal?.aborted).toBe(false)
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
### Motivation
- `createApiClient().get` の `latestOnly` 挙動を明確化して、同一 `key` の直前リクエストのみ中断するようにするため。 
- 中断時のエラー扱いと AbortController の参照リークを防止するため。 

### Description
- `frontend/src/services/api-client.ts` の GET 実装を調整し、`options.mode === 'latestOnly' && key` の場合のみ直前リクエストを `abort()` するようにした。 
- 中断用マップ名を `abortControllers` に変更し、完了時に「自分が登録されている abort ハンドラである場合のみ削除する」条件で確実にクリーンアップする実装にした。 
- `frontend/src/services/http/fetch-client.ts` に `isFetchAbortError` を追加し、GET 内で中断が起きた場合は `FetchAbortError` として上位へ再送出する方針を明文化した。 
- `frontend/tests/services/api-client-behavior.test.ts` を拡張・更新し、(1) 同一 key の連続 GET で先行リクエストが中断される、(2) 別 key では中断されない、(3) 中断後に AbortController がリークしない（副作用検証）の3ケースを追加した。 

### Testing
- 単体テスト: `cd frontend && npm run test -- tests/services/api-client-behavior.test.ts` を実行し該当テストファイルの全テストが合格した（7/7）。 
- 全テスト: `cd frontend && npm run test` を実行し、全テストが合格した（Test Files 26 passed, Tests 101 passed）。 
- その他: `cd frontend && npm run format`、`cd frontend && npm run lint`、`cd frontend && npm run typecheck` を実行し全て成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c41f3f7c8328890b2ff0621b5a21)