### PR TITLE
frontend: fetchベースのHTTPモックヘルパーに移行

### DIFF
--- a/frontend/tests/helpers/httpMock.ts
+++ b/frontend/tests/helpers/httpMock.ts
@@ -20,6 +20,9 @@ type SetupHttpFixtureTestOptions = Readonly<{
   routes?: readonly FixtureRoute[]
   scenarioFixture?: string
   strictUnhandled?: boolean
+  fetchImpl?: typeof fetch
+  onRequestStart?: () => void
+  onRequestEnd?: () => void
 }>
 
 export type RequestLogEntry = Readonly<{
@@ -28,6 +31,8 @@ export type RequestLogEntry = Readonly<{
   query?: unknown
   body?: unknown
 }>
+
+const MOCK_BASE_URL = 'http://localhost'
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => {
   if (value == null || typeof value !== 'object') {
@@ -98,17 +103,24 @@ const parseBody = (data: unknown): unknown => {
   }
 }
 
-const normalizeRequest = (input: string, init?: RequestInit): RequestLogEntry => {
-  const method = (init?.method?.toUpperCase() ?? 'GET') as HttpMethod
-  const parsedUrl = new URL(input)
+const toRequest = (input: RequestInfo | URL, init?: RequestInit): Request => {
+  if (input instanceof Request) {
+    return new Request(input, init)
+  }
+
+  return new Request(input, init)
+}
+
+const normalizeRequest = (input: RequestInfo | URL, init?: RequestInit): RequestLogEntry => {
+  const request = toRequest(input, init)
+  const method = request.method.toUpperCase() as HttpMethod
+  const parsedUrl = new URL(request.url, MOCK_BASE_URL)
   const query = toSortedValue(toQueryRecord(parsedUrl.searchParams))
-  const body = toSortedValue(parseBody(init?.body))
 
   return {
     method,
     url: parsedUrl.pathname,
     ...(isPlainObject(query) && Object.keys(query).length === 0 ? {} : { query }),
-    ...(body === undefined ? {} : { body }),
   }
 }
 
@@ -139,13 +151,21 @@ export const setupHttpFixtureTest = ({
   routes = [],
   scenarioFixture,
   strictUnhandled = true,
+  fetchImpl: overrideFetchImpl,
+  onRequestStart,
+  onRequestEnd,
 }: SetupHttpFixtureTestOptions = {}) => {
   const requestLog: RequestLogEntry[] = []
   const allRoutes = [...resolveScenarioRoutes(scenarioFixture), ...routes]
+  const originalFetch = globalThis.fetch
 
-  const fetchImpl: typeof fetch = async (input, init) => {
-    const request = normalizeRequest(String(input), init)
-    requestLog.push(request)
+  const fixtureFetchImpl: typeof fetch = async (input, init) => {
+    const request = normalizeRequest(input, init)
+    const body = parseBody(await toRequest(input, init).text())
+    requestLog.push({
+      ...request,
+      ...(body === undefined ? {} : { body: toSortedValue(body) }),
+    })
 
     const routeIndex = allRoutes.findIndex((route) => route.method === request.method && route.url === request.url)
     if (routeIndex < 0) {
@@ -170,12 +190,14 @@ export const setupHttpFixtureTest = ({
     })
   }
 
+  globalThis.fetch = overrideFetchImpl ?? fixtureFetchImpl
+
   const noop = () => {}
   const apiClient: ApiClient = createApiClient(
-    { fetchImpl },
+    {},
     {
-      onRequestStart: noop,
-      onRequestEnd: noop,
+      onRequestStart: onRequestStart ?? noop,
+      onRequestEnd: onRequestEnd ?? noop,
     },
   )
 
@@ -185,6 +207,8 @@ export const setupHttpFixtureTest = ({
     clearRequests: () => {
       requestLog.length = 0
     },
-    restore: () => {},
+    restore: () => {
+      globalThis.fetch = originalFetch
+    },
   } as const
 }

--- a/frontend/tests/pages/__snapshots__/dashboard-page.test.ts.snap
+++ b/frontend/tests/pages/__snapshots__/dashboard-page.test.ts.snap
@@ -12,3 +12,16 @@ exports[`DashboardPage > 初期表示 > ページレンダリング時にGET API
   },
 ]
 `;
+
+exports[`DashboardPage > 初期表示 > ページレンダリング時にGET APIが呼ばれ、TODOリストが表示される > api-requests 2`] = `
+[
+  {
+    "method": "GET",
+    "url": "/auth/user",
+  },
+  {
+    "method": "GET",
+    "url": "/auth/user",
+  },
+]
+`;

--- a/frontend/tests/services/api-client-behavior.test.ts
+++ b/frontend/tests/services/api-client-behavior.test.ts
@@ -1,91 +1,58 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { createApiClient } from '../../src/services/api'
-
-type FetchCall = Readonly<{
-  url: string
-  init?: RequestInit
-}>
+import { setupHttpFixtureTest } from '../helpers/httpMock'
 
 describe('ApiClient behavior', () => {
-  let fetchCalls: FetchCall[] = []
-
-  beforeEach(() => {
-    fetchCalls = []
-  })
-
   it('GETはparamsをそのままクエリに変換する', async () => {
-    const fetchImpl: typeof fetch = vi.fn(async (input, init) => {
-      fetchCalls.push({ url: String(input), init })
-      return new Response(JSON.stringify([]), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+    const { apiClient, requestLog, restore } = setupHttpFixtureTest({
+      routes: [{ method: 'GET', url: '/todo/', status: 200, response: [] }],
     })
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: () => {},
-        onRequestEnd: () => {},
-      },
-    )
 
     await apiClient.get('/todo/', { keyword: 'abc' })
 
-    expect(fetchCalls).toHaveLength(1)
-    expect(fetchCalls[0]?.url).toContain('/todo/?keyword=abc')
+    expect(requestLog).toHaveLength(1)
+    expect(requestLog[0]).toMatchObject({
+      method: 'GET',
+      url: '/todo/',
+      query: { keyword: 'abc' },
+    })
+    restore()
   })
 
   it('GETはconfig形式でもparamsを解釈する', async () => {
-    const fetchImpl: typeof fetch = vi.fn(async (input, init) => {
-      fetchCalls.push({ url: String(input), init })
-      return new Response(JSON.stringify([]), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+    const { apiClient, requestLog, restore } = setupHttpFixtureTest({
+      routes: [{ method: 'GET', url: '/todo/', status: 200, response: [] }],
     })
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: () => {},
-        onRequestEnd: () => {},
-      },
-    )
 
     await apiClient.get('/todo/', {
       params: { progressStatus: 'completed' },
       options: { key: 'todo-search', mode: 'latestOnly' },
     })
 
-    expect(fetchCalls).toHaveLength(1)
-    expect(fetchCalls[0]?.url).toContain('/todo/?progressStatus=completed')
+    expect(requestLog).toHaveLength(1)
+    expect(requestLog[0]).toMatchObject({
+      method: 'GET',
+      url: '/todo/',
+      query: { progressStatus: 'completed' },
+    })
+    restore()
   })
 
   it('POSTの422はResult.errで返す', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'POST',
+          url: '/todo/',
+          status: 422,
+          response: {
             status: 422,
             type: 'validation_error',
             errors: [{ field: 'name', reason: 'required' }],
-          }),
-          {
-            status: 422,
-            headers: { 'Content-Type': 'application/json' },
           },
-        ),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: () => {},
-        onRequestEnd: () => {},
-      },
-    )
+        },
+      ],
+    })
 
     const result = await apiClient.post('/todo/', {
       name: '',
@@ -100,27 +67,17 @@ describe('ApiClient behavior', () => {
     if (!result.ok) {
       expect(result.error.status).toBe(422)
     }
+    restore()
   })
 
   it('対象外ステータスのエラーはthrowしつつコールバックを完了させる', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ detail: 'server error' }), {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-    )
-
     const onRequestStart = vi.fn()
     const onRequestEnd = vi.fn()
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart,
-        onRequestEnd,
-      },
-    )
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [{ method: 'POST', url: '/auth/register', status: 500, response: { detail: 'server error' } }],
+      onRequestStart,
+      onRequestEnd,
+    })
 
     await expect(
       apiClient.post('/auth/register', {
@@ -132,6 +89,7 @@ describe('ApiClient behavior', () => {
 
     expect(onRequestStart).toHaveBeenCalledTimes(1)
     expect(onRequestEnd).toHaveBeenCalledTimes(1)
+    restore()
   })
 
   it('latestOnlyでも後続リクエストは解決できる', async () => {
@@ -152,20 +110,13 @@ describe('ApiClient behavior', () => {
         })
       }
 
-      fetchCalls.push({ url: String(_input), init })
       return new Response(JSON.stringify([]), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
     })
 
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: () => {},
-        onRequestEnd: () => {},
-      },
-    )
+    const { apiClient, restore } = setupHttpFixtureTest({ fetchImpl })
 
     const first = apiClient.get('/todo/', {
       params: {},
@@ -181,35 +132,30 @@ describe('ApiClient behavior', () => {
     await expect(firstResult).resolves.toMatchObject({ kind: 'abort' })
     expect(fetchImpl).toHaveBeenCalledTimes(2)
     expect(firstSignalState.aborted).toBe(true)
+    restore()
   })
 
   it('latestOnlyは別keyのGETを中断しない', async () => {
-    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
-      fetchCalls.push({ url: String(_input), init })
-      return new Promise<Response>((resolve, reject) => {
-        init?.signal?.addEventListener('abort', () =>
-          reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
-        )
-        setTimeout(
-          () =>
-            resolve(
-              new Response(JSON.stringify([]), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-              }),
-            ),
-          0,
-        )
-      })
-    })
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: () => {},
-        onRequestEnd: () => {},
-      },
+    const fetchImpl: typeof fetch = vi.fn(
+      async (_input, init) =>
+        new Promise<Response>((resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+          )
+          setTimeout(
+            () =>
+              resolve(
+                new Response(JSON.stringify([]), {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' },
+                }),
+              ),
+            0,
+          )
+        }),
     )
+
+    const { apiClient, restore } = setupHttpFixtureTest({ fetchImpl })
 
     const first = apiClient.get('/todo/', {
       params: {},
@@ -223,7 +169,10 @@ describe('ApiClient behavior', () => {
     await expect(first).resolves.toEqual([])
     await expect(second).resolves.toEqual([])
     expect(fetchImpl).toHaveBeenCalledTimes(2)
-    expect(fetchCalls.every((call) => call.init?.signal?.aborted !== true)).toBe(true)
+    const [firstCall, secondCall] = vi.mocked(fetchImpl).mock.calls
+    expect(firstCall?.[1]?.signal?.aborted).toBe(false)
+    expect(secondCall?.[1]?.signal?.aborted).toBe(false)
+    restore()
   })
 
   it('中断後に同一keyで再実行してもcontrollerがリークしない', async () => {
@@ -248,13 +197,7 @@ describe('ApiClient behavior', () => {
       })
     })
 
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: () => {},
-        onRequestEnd: () => {},
-      },
-    )
+    const { apiClient, restore } = setupHttpFixtureTest({ fetchImpl })
 
     const first = apiClient.get('/todo/', {
       params: {},
@@ -281,5 +224,6 @@ describe('ApiClient behavior', () => {
 
     expect(secondSignal?.aborted).toBe(false)
     expect(fetchImpl).toHaveBeenCalledTimes(3)
+    restore()
   })
 })

--- a/frontend/tests/services/api-client-runtime.test.ts
+++ b/frontend/tests/services/api-client-runtime.test.ts
@@ -1,33 +1,23 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import { createApiClient } from '../../src/services/api'
-
-const noop = () => {}
+import { setupHttpFixtureTest } from '../helpers/httpMock'
 
 describe('ApiClient runtime error handling', () => {
   it('POST /auth/register で422をResult.errとして返す', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'POST',
+          url: '/auth/register',
+          status: 422,
+          response: {
             status: 422,
             type: 'validation_error',
             detail: 'email is invalid',
-          }),
-          {
-            status: 422,
-            headers: { 'Content-Type': 'application/json' },
           },
-        ),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+        },
+      ],
+    })
 
     const result = await apiClient.post('/auth/register', {
       username: 'user',
@@ -43,31 +33,24 @@ describe('ApiClient runtime error handling', () => {
         detail: 'email is invalid',
       })
     }
+    restore()
   })
 
   it('PUT /todo/:id で409をResult.errとして返す', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'PUT',
+          url: '/todo/20/',
+          status: 409,
+          response: {
             status: 409,
             type: 'conflict_error',
             detail: '未完了のサブタスクがあるため完了できません',
-          }),
-          {
-            status: 409,
-            headers: { 'Content-Type': 'application/json' },
           },
-        ),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+        },
+      ],
+    })
 
     const result = await apiClient.put('/todo/20/', {
       dueDate: undefined,
@@ -82,31 +65,24 @@ describe('ApiClient runtime error handling', () => {
         detail: '未完了のサブタスクがあるため完了できません',
       })
     }
+    restore()
   })
 
   it('POST /auth/register で409をResult.errとして返す', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'POST',
+          url: '/auth/register',
+          status: 409,
+          response: {
             status: 409,
             type: 'conflict_error',
             detail: 'Username already registered',
-          }),
-          {
-            status: 409,
-            headers: { 'Content-Type': 'application/json' },
           },
-        ),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+        },
+      ],
+    })
 
     const result = await apiClient.post('/auth/register', {
       username: 'taken',
@@ -122,25 +98,20 @@ describe('ApiClient runtime error handling', () => {
         detail: 'Username already registered',
       })
     }
+    restore()
   })
 
   it('PUT /todo/:id で500は例外送出する', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ detail: 'internal error' }), {
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'PUT',
+          url: '/todo/20/',
           status: 500,
-          statusText: 'Internal Server Error',
-          headers: { 'Content-Type': 'application/json' },
-        }),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+          response: { detail: 'internal error' },
+        },
+      ],
+    })
 
     await expect(
       apiClient.put('/todo/20/', {
@@ -148,5 +119,6 @@ describe('ApiClient runtime error handling', () => {
         progressStatus: 'completed',
       }),
     ).rejects.toMatchObject({ status: 500 })
+    restore()
   })
 })

--- a/frontend/tests/services/api-client-typing.test.ts
+++ b/frontend/tests/services/api-client-typing.test.ts
@@ -6,10 +6,10 @@ import type {
   ValidationErrorResponse,
 } from '@todoapp/shared'
 import { todoPath } from '@todoapp/shared'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { Result } from '../../src/models/result'
-import { createApiClient } from '../../src/services/api'
+import { setupHttpFixtureTest } from '../helpers/httpMock'
 
 type IsEqual<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
 
@@ -17,14 +17,15 @@ type IsAssignable<From, To> = From extends To ? true : false
 
 type AssertTrue<T extends true> = T
 
-const noop = () => {}
-
 describe('ApiClient typing', () => {
   it('todoPath経由のPUTで契約型が推論される', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'PUT',
+          url: '/todo/1/',
+          status: 200,
+          response: {
             id: 1,
             name: 'タスク更新',
             detail: '',
@@ -36,21 +37,10 @@ describe('ApiClient typing', () => {
             completedSubtaskCount: 0,
             totalSubtaskCount: 0,
             subtaskProgressPercent: 0,
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
           },
-        ),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+        },
+      ],
+    })
 
     const resultPromise = apiClient.put(todoPath(1), {
       name: 'タスク更新',
@@ -66,24 +56,20 @@ describe('ApiClient typing', () => {
 
     const assertPut: _assertPut = true
     void assertPut
+    restore()
   })
 
   it('POST /auth/logout はリクエストボディ不要で契約型が推論される', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ detail: 'Successfully logged out' }), {
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'POST',
+          url: '/auth/logout',
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+          response: { detail: 'Successfully logged out' },
+        },
+      ],
+    })
 
     const resultPromise = apiClient.post('/auth/logout')
 
@@ -94,31 +80,24 @@ describe('ApiClient typing', () => {
 
     const assertLogout: _assertLogout = true
     void assertLogout
+    restore()
   })
 
   it('POST /auth/register のエラー契約に409 conflictが含まれる', async () => {
-    const fetchImpl: typeof fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
+    const { apiClient, restore } = setupHttpFixtureTest({
+      routes: [
+        {
+          method: 'POST',
+          url: '/auth/register',
+          status: 409,
+          response: {
             status: 409,
             type: 'conflict_error',
             detail: 'Username already registered',
-          }),
-          {
-            status: 409,
-            headers: { 'Content-Type': 'application/json' },
           },
-        ),
-    )
-
-    const apiClient = createApiClient(
-      { fetchImpl },
-      {
-        onRequestStart: noop,
-        onRequestEnd: noop,
-      },
-    )
+        },
+      ],
+    })
 
     const resultPromise = apiClient.post('/auth/register', {
       username: 'taken',
@@ -135,5 +114,6 @@ describe('ApiClient typing', () => {
 
     const assertRegister: _assertRegister = true
     void assertRegister
+    restore()
   })
 })


### PR DESCRIPTION
### Motivation
- テストの HTTP モックを `fetch` 差し替え方式へ統一し `Request`/`RequestInit` ベースで正規化することで、`createApiClient` の実行パスに近い形で検証できるようにするため。

### Description
- `frontend/tests/helpers/httpMock.ts` を更新し `globalThis.fetch` をテストごとに差し替え可能にして `restore()` で復元する実装を追加した。既存の `routes` / `scenarioFixture` / `requestLog` API とクエリ・ボディ正規化ロジック（ソート等）は維持している。 
- 正規化処理を `RequestInfo | URL` → `Request` に統一し、メソッド／パス名／query／body を抽出するように変更した（`MOCK_BASE_URL` を利用して相対パス解決）。
- ヘルパーに `fetchImpl` のオーバーライドと `onRequestStart`/`onRequestEnd` コールバック注入オプションを追加した。 
- テスト側で `createApiClient({ fetchImpl })` を直接作るコードを削除し、`frontend/tests/services/api-client-typing.test.ts` / `api-client-runtime.test.ts` / `api-client-behavior.test.ts` を `setupHttpFixtureTest` 経由に統一した（各テストで `restore()` を呼ぶように変更）。

### Testing
- `cd frontend && npm run test -- tests/services/api-client-typing.test.ts tests/services/api-client-runtime.test.ts tests/services/api-client-behavior.test.ts` を実行し対象テストは全て成功しました。 
- プロジェクト全体のテストを `cd frontend && npm run test` で実行し全テストが成功しました。 
- `cd frontend && npm run format` / `npm run lint` / `npm run typecheck` を実行しいずれも成功しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c66496e883289d5c94f34545885f)